### PR TITLE
Add dependabot check for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,8 @@ updates:
     time: "03:00"
   open-pull-requests-limit: 10
   allow:
-    - dependency-type: production
+    - dependency-type: production- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "03:00"


### PR DESCRIPTION
As some of the GitHub Actions may soon become deprectaed, I am adding a check to dependabot to keep our actions up to date.